### PR TITLE
Added base entity classes in Shared project

### DIFF
--- a/Fluid.Shared/Contracts/IEntity.cs
+++ b/Fluid.Shared/Contracts/IEntity.cs
@@ -1,0 +1,11 @@
+﻿namespace Fluid.Shared.Contracts;
+
+public interface IEntity
+{
+
+}
+
+public interface IEntity<TId> : IEntity
+{
+    TId Id { get; set; }
+}

--- a/Fluid.Shared/Entities/ComponentType.cs
+++ b/Fluid.Shared/Entities/ComponentType.cs
@@ -1,0 +1,7 @@
+﻿namespace Fluid.Shared.Entities;
+
+public class ComponentType : IEntity<string>
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+}

--- a/Fluid.Shared/Entities/HardDiskInfo.cs
+++ b/Fluid.Shared/Entities/HardDiskInfo.cs
@@ -1,0 +1,30 @@
+﻿namespace Fluid.Shared.Entities;
+
+public class HardDiskInfo : IEntity
+{
+    [Key]
+    public string OemSerialNo { get; set; }
+
+    public string Manufacturer { get; set; }
+
+    public string Model { get; set; }
+
+    public UseStatus UseStatus { get; set; }
+
+    public DriveMediaType MediaType { get; set; }
+
+    public DriveBusType BusType { get; set; }
+
+    public DriveHealthCondition HealthCondition { get; set; }
+
+    public int Size { get; set; }
+
+    public MachineInfo? Machine { get; set; }
+    public string? MachineId { get; set; }
+
+    public DateTime? PurchaseDate { get; set; }
+
+    public decimal Price { get; set; }
+
+    public ComponentType ComponentType { get; set; }
+}

--- a/Fluid.Shared/Entities/KeyboardInfo.cs
+++ b/Fluid.Shared/Entities/KeyboardInfo.cs
@@ -1,0 +1,24 @@
+﻿namespace Fluid.Shared.Entities;
+
+public class KeyboardInfo : IEntity
+{
+    [Key]
+    public string OemSerialNo { get; set; }
+
+    public string Manufacturer { get; set; }
+
+    public string Model { get; set; }
+
+    public string IsWireless { get; set; }
+
+    public string Description { get; set; }
+
+    public MachineInfo? Machine { get; set; }
+    public string? MachineId { get; set; }
+
+    public DateTime? PurchaseDate { get; set; }
+
+    public decimal Price { get; set; }
+
+    public ComponentType ComponentType { get; set; }
+}

--- a/Fluid.Shared/Entities/MachineInfo.cs
+++ b/Fluid.Shared/Entities/MachineInfo.cs
@@ -1,0 +1,33 @@
+﻿namespace Fluid.Shared.Entities;
+
+public class MachineInfo : IEntity
+{
+    [Key]
+    public string OemServiceTag { get; set; } //Primary Key
+
+    public string OemSerialNo { get; set; }
+
+    public string MachineName { get; set; }
+
+    public string Model { get; set; }
+
+    public string Manufacturer { get; set; }
+
+    public MachineType MachineType { get; set; }
+
+    public MachineUseType UseType { get; set; }
+
+    public UseStatus UseStatus { get; set; }
+
+    public string AssignedPersonName { get; set; }
+
+    public string AssetLocation { get; set; }
+
+    public string AssetBranch { get; set; }
+
+    public DateTime? PurchaseDate { get; set; }
+
+    public DateTime? InitializationDate { get; set; }
+
+    public decimal Price { get; set; }
+}

--- a/Fluid.Shared/Entities/MotherboardInfo.cs
+++ b/Fluid.Shared/Entities/MotherboardInfo.cs
@@ -1,0 +1,22 @@
+﻿namespace Fluid.Shared.Entities;
+
+public class MotherboardInfo
+{
+    [Key]
+    public string OemSerialNo { get; set; }
+
+    public string Manufacturer { get; set; }
+
+    public string Model { get; set; }
+
+    public UseStatus UseStatus { get; set; }
+
+    public MachineInfo? Machine { get; set; }
+    public string? MachineId { get; set; }
+
+    public DateTime? PurchaseDate { get; set; }
+
+    public decimal Price { get; set; }
+
+    public ComponentType ComponentType { get; set; }
+}

--- a/Fluid.Shared/Entities/MouseInfo.cs
+++ b/Fluid.Shared/Entities/MouseInfo.cs
@@ -1,0 +1,24 @@
+﻿namespace Fluid.Shared.Entities;
+
+public class MouseInfo : IEntity
+{
+    [Key]
+    public string OemSerialNo { get; set; }
+
+    public string Manufacturer { get; set; }
+
+    public string Model { get; set; }
+
+    public string IsWireless { get; set; }
+
+    public string Description { get; set; }
+
+    public MachineInfo? Machine { get; set; }
+    public string? MachineId { get; set; }
+
+    public DateTime? PurchaseDate { get; set; }
+
+    public decimal Price { get; set; }
+
+    public ComponentType ComponentType { get; set; }
+}

--- a/Fluid.Shared/Entities/PhysicalMemoryInfo.cs
+++ b/Fluid.Shared/Entities/PhysicalMemoryInfo.cs
@@ -1,0 +1,28 @@
+﻿namespace Fluid.Shared.Entities;
+
+public class PhysicalMemoryInfo : IEntity
+{
+    [Key]
+    public string OemSerialNo { get; set; }
+
+    public string Manufacturer { get; set; }
+
+    public UseStatus UseStatus { get; set; }
+
+    public int Capacity { get; set; }
+
+    public double Speed { get; set; }
+
+    public MemoryType MemoryType { get; set; }
+
+    public MemoryFormFactor FormFactor { get; set; }
+
+    public MachineInfo? Machine { get; set; }
+    public string? MachineId { get; set; }
+
+    public DateTime? PurchaseDate { get; set; }
+
+    public decimal Price { get; set; }
+
+    public ComponentType ComponentType { get; set; }
+}

--- a/Fluid.Shared/Enums/MachineType.cs
+++ b/Fluid.Shared/Enums/MachineType.cs
@@ -1,0 +1,8 @@
+﻿namespace Fluid.Shared.Enums;
+
+public enum MachineType : byte
+{
+    PC,
+    Workstation,
+    Laptop
+}

--- a/Fluid.Shared/Enums/MachineUseType.cs
+++ b/Fluid.Shared/Enums/MachineUseType.cs
@@ -1,0 +1,7 @@
+﻿namespace Fluid.Shared.Enums;
+
+public enum MachineUseType : byte
+{
+    PersonUse,
+    CommonUse
+}

--- a/Fluid.Shared/Enums/Technical/DriveBusType.cs
+++ b/Fluid.Shared/Enums/Technical/DriveBusType.cs
@@ -1,4 +1,4 @@
-﻿namespace Fluid.Shared.Enums
+﻿namespace Fluid.Shared.Enums.Technical
 {
     public enum DriveBusType : byte
     {

--- a/Fluid.Shared/Enums/Technical/DriveHealthCondition.cs
+++ b/Fluid.Shared/Enums/Technical/DriveHealthCondition.cs
@@ -1,4 +1,4 @@
-﻿namespace Fluid.Shared.Enums
+﻿namespace Fluid.Shared.Enums.Technical
 {
     public enum DriveHealthCondition : byte
     {

--- a/Fluid.Shared/Enums/Technical/DriveMediaType.cs
+++ b/Fluid.Shared/Enums/Technical/DriveMediaType.cs
@@ -1,4 +1,4 @@
-﻿namespace Fluid.Shared.Enums
+﻿namespace Fluid.Shared.Enums.Technical
 {
     public enum DriveMediaType : byte
     {

--- a/Fluid.Shared/Enums/Technical/MemoryFormFactor.cs
+++ b/Fluid.Shared/Enums/Technical/MemoryFormFactor.cs
@@ -1,4 +1,4 @@
-﻿namespace Fluid.Shared.Enums;
+﻿namespace Fluid.Shared.Enums.Technical;
 public enum MemoryFormFactor : byte
 {
     Unknown = 0,

--- a/Fluid.Shared/Enums/Technical/MemoryType.cs
+++ b/Fluid.Shared/Enums/Technical/MemoryType.cs
@@ -1,4 +1,4 @@
-﻿namespace Fluid.Shared.Enums;
+﻿namespace Fluid.Shared.Enums.Technical;
 public enum MemoryType : byte
 {
     Other = 1,

--- a/Fluid.Shared/Enums/Technical/ProcessorArchitecture.cs
+++ b/Fluid.Shared/Enums/Technical/ProcessorArchitecture.cs
@@ -1,4 +1,4 @@
-﻿namespace Fluid.Shared.Enums;
+﻿namespace Fluid.Shared.Enums.Technical;
 public enum ProcessorArchitecture : byte
 {
     x86 = 0,

--- a/Fluid.Shared/Enums/UseStatus.cs
+++ b/Fluid.Shared/Enums/UseStatus.cs
@@ -1,0 +1,10 @@
+﻿namespace Fluid.Shared.Enums;
+
+public enum UseStatus : byte
+{
+    InUse,
+    UnderRepair,
+    UnderSpare,
+    ToBeScrapped,
+    Disposed
+}

--- a/Fluid.Shared/_Imports.cs
+++ b/Fluid.Shared/_Imports.cs
@@ -1,0 +1,4 @@
+﻿global using Fluid.Shared.Contracts;
+global using Fluid.Shared.Enums;
+global using Fluid.Shared.Enums.Technical;
+global using System.ComponentModel.DataAnnotations;


### PR DESCRIPTION
* Added _Contract_ interfaces (`IEntity`, `IEntity<TId>`) - These empty interfaces are particularly useful when implementing _Repository pattern_ to access database.
* Added base entities in `Fluid.Shared.Entities` - All these classes implement the `IEntity` interface.
* Moved existing enums into new `Technical` subfolder, for better clarity
* Added new `_Imports.cs` where the `global using` statements are placed. The namespaces imported here, are imported for the entire `Fluid.Shared` project.