### PR TITLE
Added new project: Fluid.Core

### DIFF
--- a/Fluid.Core/Extensions/DependencyInjection.cs
+++ b/Fluid.Core/Extensions/DependencyInjection.cs
@@ -1,0 +1,17 @@
+﻿using Fluid.Core.Persistence;
+using Fluid.Core.Repositories;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fluid.Core.Extensions;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration configuration, string connectionStringKey)
+    {
+        services.AddDbContext<AppDbContext>(options => options.UseSqlServer(configuration.GetConnectionString(connectionStringKey)));
+        services.AddTransient<IUnitOfWork, UnitOfWork>();
+        services.AddTransient(typeof(IRepositoryAsync<>), typeof(RepositoryAsync<>));
+        return services;
+    }
+}

--- a/Fluid.Core/Fluid.Core.csproj
+++ b/Fluid.Core/Fluid.Core.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fluid.Shared\Fluid.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Fluid.Core/Interfaces/Repositories/IRepositoryAsync.cs
+++ b/Fluid.Core/Interfaces/Repositories/IRepositoryAsync.cs
@@ -1,0 +1,24 @@
+﻿using Fluid.Shared.Contracts;
+
+namespace Fluid.Core.Interfaces.Repositories;
+
+public interface IRepositoryAsync<T> where T : class, IEntity
+{
+    IQueryable<T> Entities { get; }
+
+    Task<T> AddAsync(T entity);
+
+    Task<int> CountAsync();
+
+    Task<int> CountAsync(Expression<Func<T, bool>> predicate);
+
+    Task DeleteAsync(T entity);
+
+    Task<List<T>> GetAllAsync();
+
+    Task<T> GetByIdAsync<TId>(TId id);
+
+    Task<List<T>> GetPagedResponseAsync(int pageNumber, int pageSize);
+
+    Task UpdateAsync<TId>(T updatedEntity, TId id);
+}

--- a/Fluid.Core/Interfaces/Repositories/IUnitOfWork.cs
+++ b/Fluid.Core/Interfaces/Repositories/IUnitOfWork.cs
@@ -1,0 +1,10 @@
+﻿using Fluid.Shared.Contracts;
+
+namespace Fluid.Core.Interfaces.Repositories;
+
+public interface IUnitOfWork : IDisposable
+{
+    IRepositoryAsync<T> GetRepository<T>() where T : class, IEntity;
+
+    Task<int> Commit();
+}

--- a/Fluid.Core/Persistence/AppDbContext.cs
+++ b/Fluid.Core/Persistence/AppDbContext.cs
@@ -1,0 +1,25 @@
+﻿using Fluid.Shared.Entities;
+
+namespace Fluid.Core.Persistence;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<MachineInfo> MachineMaster { get; set; }
+    public DbSet<ComponentType> ComponentTypes { get; set; }
+    public DbSet<MotherboardInfo> MotherboardMaster { get; set; }
+    public DbSet<PhysicalMemoryInfo> PhysicalMemoryMaster { get; set; }
+    public DbSet<HardDiskInfo> HardDiskMaster { get; set; }
+    public DbSet<KeyboardInfo> KeyboardMaster { get; set; }
+    public DbSet<MouseInfo> MouseMaster { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        foreach (var property in modelBuilder.Model.GetEntityTypes().SelectMany(t => t.GetProperties()).Where(p => p.ClrType == typeof(decimal) || p.ClrType == typeof(decimal?)))
+        {
+            property.SetColumnType("decimal(18,2)");
+        }
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/Fluid.Core/Repositories/RepositoryAsync.cs
+++ b/Fluid.Core/Repositories/RepositoryAsync.cs
@@ -1,0 +1,57 @@
+﻿using Fluid.Core.Persistence;
+using Fluid.Shared.Contracts;
+
+namespace Fluid.Core.Repositories;
+
+public class RepositoryAsync<T> : IRepositoryAsync<T> where T : class, IEntity
+{
+    private readonly AppDbContext _appDbContext;
+
+    public RepositoryAsync(AppDbContext appDbContext) => _appDbContext = appDbContext;
+
+    public IQueryable<T> Entities => _appDbContext.Set<T>();
+
+    public async Task<T> AddAsync(T entity)
+    {
+        await _appDbContext.Set<T>().AddAsync(entity);
+        return entity;
+    }
+
+    public async Task<int> CountAsync(Expression<Func<T, bool>> predicate)
+    {
+        return await _appDbContext.Set<T>().CountAsync(predicate);
+    }
+
+    public async Task<int> CountAsync()
+    {
+        return await _appDbContext.Set<T>().CountAsync();
+    }
+
+    public async Task DeleteAsync(T entity)
+    {
+        _appDbContext.Set<T>().Remove(entity);
+        await Task.CompletedTask;
+    }
+
+    public async Task<List<T>> GetAllAsync()
+    {
+        return await _appDbContext.Set<T>().ToListAsync();
+    }
+
+    public async Task<T> GetByIdAsync<TId>(TId id)
+    {
+        return await _appDbContext.Set<T>().FindAsync(id);
+    }
+
+    public async Task<List<T>> GetPagedResponseAsync(int pageNumber, int pageSize)
+    {
+        return await _appDbContext.Set<T>().Skip((pageNumber - 1) * pageSize).Take(pageSize).AsNoTracking().ToListAsync();
+    }
+
+    public async Task UpdateAsync<TId>(T updatedEntity, TId id)
+    {
+        T old = await _appDbContext.Set<T>().FindAsync(id);
+        _appDbContext.Entry(old).CurrentValues.SetValues(updatedEntity);
+        await Task.CompletedTask;
+    }
+}

--- a/Fluid.Core/Repositories/UnitOfWork.cs
+++ b/Fluid.Core/Repositories/UnitOfWork.cs
@@ -1,0 +1,56 @@
+﻿using Fluid.Core.Persistence;
+using Fluid.Shared.Contracts;
+using System.Collections;
+
+namespace Fluid.Core.Repositories;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly AppDbContext _appDbContext;
+    private bool _disposed;
+    private Hashtable _repositories;
+
+    public UnitOfWork(AppDbContext appDbContext) => _appDbContext = appDbContext;
+
+    public IRepositoryAsync<T> GetRepository<T>() where T : class, IEntity
+    {
+        if (_repositories == null)
+            _repositories = new Hashtable();
+
+        var type = typeof(T).Name;
+
+        if (!_repositories.ContainsKey(type))
+        {
+            var repositoryType = typeof(RepositoryAsync<>);
+            var repositoryInstance = Activator.CreateInstance(repositoryType.MakeGenericType(typeof(T)), _appDbContext);
+            _repositories.Add(type, repositoryInstance);
+        }
+
+        return (IRepositoryAsync<T>)_repositories[type];
+    }
+
+    public async Task<int> Commit()
+    {
+        return await _appDbContext.SaveChangesAsync();
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                //dispose managed resources
+                _appDbContext.Dispose();
+            }
+        }
+        //dispose unmanaged resources
+        _disposed = true;
+    }
+}

--- a/Fluid.Core/_Imports.cs
+++ b/Fluid.Core/_Imports.cs
@@ -1,0 +1,3 @@
+﻿global using Fluid.Core.Interfaces.Repositories;
+global using Microsoft.EntityFrameworkCore;
+global using System.Linq.Expressions;

--- a/GR918.sln
+++ b/GR918.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fluid.Client", "Fluid.Clien
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fluid.Shared", "Fluid.Shared\Fluid.Shared.csproj", "{DDBA82AD-F48F-41AE-A3CE-F689DB4618AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fluid.Core", "Fluid.Core\Fluid.Core.csproj", "{F392964E-00B7-4D1B-B360-9FD70AF96D00}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{DDBA82AD-F48F-41AE-A3CE-F689DB4618AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DDBA82AD-F48F-41AE-A3CE-F689DB4618AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DDBA82AD-F48F-41AE-A3CE-F689DB4618AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F392964E-00B7-4D1B-B360-9FD70AF96D00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F392964E-00B7-4D1B-B360-9FD70AF96D00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F392964E-00B7-4D1B-B360-9FD70AF96D00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F392964E-00B7-4D1B-B360-9FD70AF96D00}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Added new project: `Fluid.Core` - A class library project that will contain the core _business logic_ of the application we build.
* Added `AppDbContext` - Provides the context for performing database operations from the code and required for database migrations.
* Added `UnitOfWork` and `RepositoryAsync` services - Used to implement ready-made functions for performing database operations. Uses the `AppDbContext` under the hood for the DB Operations
* Added `DependencyInjection` class that is used to create _extension methods_ for registering the services we use, at the application startup - For now, there is only one method which will be used to register the `UnitOfWork` and `RepositoryAsync` services.